### PR TITLE
Hide theme GitHub profile button

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@
     color: white; /* Ensure bold text inside links also turns white */
   }
 
+  /* Hide the GitHub profile button rendered by the theme header */
+  a.btn[href*="github.com"] {
+    display: none !important;
+  }
+
   li {
     margin: 0; /* Remove any unnecessary margin */
     padding: 0; /* Remove padding from list items */


### PR DESCRIPTION
## Summary
- hide the GitHub profile button rendered by the theme so it no longer appears under the headshot

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691290fe8da88330b438142f77874406)