### PR TITLE
Refine responsive layout and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,6 @@
-<header style="background-color: white; padding: 0; margin-bottom: 0; position: relative; height: 36px; border-radius: 4px; display: flex; align-items: center;">
-  <nav style="margin: 0; padding: 0; width: 100%;">
-    <ul style="list-style-type: none; padding: 0; margin: 0; display: flex; align-items: center; height: 100%;">
-
-      <li style="margin: 0 20px 0 0; padding: 0; display: flex; align-items: center;"> <!-- Set margin-right to 20px -->
-        <a href="https://tanvirnwu.github.io/" class="active-menu">
-  <strong>About</strong></a> </li>
-      
-      <li style="margin: 0 20px 0 0; padding: 0; display: flex; align-items: center;"> <!-- Set margin-right to 20px -->
-        <a href="https://tanvirnwu.github.io/pages/publications" style="font-size: 12px; color: #343434; text-decoration: none; padding: 9px 15px; border-radius: 4px; box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1); transition: background-color 0.3s, color 0.3s; display: block;">
-          <strong>Publications</strong>
-        </a>
-      </li>
-
-      
-      <li style="margin: 0 20px 0 0; padding: 0; display: flex; align-items: center;"> <!-- Set margin-right to 20px -->
-        <a href="https://tanvirnwu.github.io/pages/datasets" style="font-size: 12px; color: #343434; text-decoration: none; padding: 9px 15px; border-radius: 4px; box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1); transition: background-color 0.3s, color 0.3s; display: block;">
-          <strong>Datasets</strong>
-        </a>
-      </li>
-        
-      <li style="margin: 0; padding: 0; display: flex; align-items: center;">
-  <a href="https://tanvirnwu.github.io/assets/TanvirResume.pdf" 
-     target="_blank" 
-     rel="noopener noreferrer"
-     style="font-size: 12px; color: #343434; text-decoration: none; padding: 9px 15px; border-radius: 4px; box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1); transition: background-color 0.3s, color 0.3s; display: block;">
-    <strong>Resume</strong>
-  </a>
-</li>
-
-    </ul>
-  </nav>
-</header>
+---
+layout: default
+---
 
 <style>
   .active-menu {
@@ -161,12 +131,19 @@ window.onscroll = function() {
 
 
 
-<h2 style=" font-size:18px; margin-top: 70px; color:#343434;"><strong>Md Tanvir Islam</strong><br>
-</h2>
-  <p style= "font-size:14px; color:#343434;">
-    Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class= "urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class= "urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class= "urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS). Based on his excellent academic and research performance, he was awarded the <i>``Academic Excellence Award Winner''</i> in 2024 by the NIIED, Government of South Korea. Currently, research assistant at VIS2KNOW Lab he is focusing on multiple emerging topics such as image dehazing, image enhancement, invisible watermarking, marked by several research outcomes published in high impactful conferences and journals such as <i><strong>WACV'26, ICCV'25, CIKM'25, WWW'25, ACM MM'24, ACCV'24, Alexandria Engineering Journal and Engineering Application of Artificial Intelligence</strong></i>. Md Tanvir Islam's passion for innovative applications of computer science and artificial intelligence is evident through his <a class= "urls" href="https://tanvirnwu.github.io/pages/publications" target="_blank">research outcomes</a> published at reputable venues.
-    <br>
-  </p>
+<div class="profile-hero">
+  <div class="profile-photo">
+    <img src="{{ site.logo | relative_url }}" alt="Portrait of Md Tanvir Islam" class="profile-image" />
+  </div>
+  <div class="profile-body">
+    <h2 style=" font-size:18px; margin-top: 70px; color:#343434;"><strong>Md Tanvir Islam</strong><br>
+    </h2>
+      <p style= "font-size:14px; color:#343434;">
+        Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class= "urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class= "urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class= "urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS). Based on his excellent academic and research performance, he was awarded the <i>``Academic Excellence Award Winner''</i> in 2024 by the NIIED, Government of South Korea. Currently, research assistant at VIS2KNOW Lab he is focusing on multiple emerging topics such as image dehazing, image enhancement, invisible watermarking, marked by several research outcomes published in high impactful conferences and journals such as <i><strong>WACV'26, ICCV'25, CIKM'25, WWW'25, ACM MM'24, ACCV'24, Alexandria Engineering Journal and Engineering Application of Artificial Intelligence</strong></i>. Md Tanvir Islam's passion for innovative applications of computer science and artificial intelligence is evident through his <a class= "urls" href="https://tanvirnwu.github.io/pages/publications" target="_blank">research outcomes</a> published at reputable venues.
+        <br>
+      </p>
+  </div>
+</div>
   <hr>
 
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="{{ site.lang | default: 'en-US' }}">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ page.title | default: site.title | default: site.github.repository_name }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+  </head>
+  <body>
+    <div class="wrapper">
+      <header class="site-header">
+        <nav class="site-nav-bar">
+          <div class="nav-inner">
+            <div class="nav-brand">
+              {% if site.logo %}
+                <a class="brand-logo-link" href="{{ '/' | relative_url }}">
+                  <img src="{{ site.logo | relative_url }}" alt="{{ site.title | default: site.github.repository_name }}" class="brand-logo">
+                </a>
+              {% endif %}
+              {% assign brand_title = site.title | strip | default: site.github.repository_name %}
+              {% if brand_title == '' %}{% assign brand_title = 'About' %}{% endif %}
+              <a class="brand-title" href="{{ '/' | relative_url }}">{{ brand_title }}</a>
+            </div>
+            <ul class="nav-links">
+              <li><a class="page-link" href="{{ '/' | relative_url }}">About</a></li>
+              {% for path in site.header_pages %}
+                {% assign my_page = site.pages | where: "path", path | first %}
+                {% if my_page %}
+                  <li><a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a></li>
+                {% endif %}
+              {% endfor %}
+              <li>
+                <a class="page-link" href="{{ '/assets/TanvirResume.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Resume</a>
+              </li>
+            </ul>
+          </div>
+        </nav>
+      </header>
+      <main class="page-shell" role="main">
+        <div class="content-inner">
+          {{ content }}
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,186 @@
+---
+---
+@import url("https://fonts.googleapis.com/css?family=Open+Sans:400,600&display=swap");
+@import "{{ site.theme }}";
+
+:root {
+  --page-max: 1380px;
+  --page-padding: clamp(18px, 4vw, 36px);
+  --layout-gap: clamp(32px, 4vw, 48px);
+  --profile-width: clamp(280px, 30vw, 320px);
+}
+
+body {
+  margin: 0;
+  overflow-x: hidden;
+  font-family: "Open Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #343434;
+}
+
+.wrapper {
+  width: 100%;
+  max-width: none;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+/* Full-width navigation with constrained inner content */
+.site-nav-bar {
+  width: 100%;
+  border-bottom: 1px solid #e6e6e6;
+  background: #ffffff;
+}
+
+.nav-inner {
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: 12px var(--page-padding);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 200px;
+}
+
+.brand-logo {
+  width: clamp(72px, 14vw, 110px);
+  height: auto;
+  border-radius: 12px;
+}
+
+.brand-title {
+  font-weight: 700;
+  font-size: 16px;
+  color: #343434;
+  text-decoration: none;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links .page-link {
+  font-size: 13px;
+  color: #343434;
+  text-decoration: none;
+  padding: 9px 14px;
+  border-radius: 6px;
+  box-shadow: 0 2px 18px rgba(0, 0, 0, 0.08);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.nav-links .page-link:hover,
+.nav-links .page-link:focus {
+  background: #6a5acd;
+  color: #ffffff;
+}
+
+/* Main content container */
+.page-shell {
+  width: 100%;
+}
+
+.content-inner {
+  width: 100%;
+  max-width: var(--page-max);
+  margin: 0 auto;
+  padding: 32px var(--page-padding) 72px;
+  box-sizing: border-box;
+}
+
+/* Profile hero layout */
+.profile-hero {
+  display: grid;
+  grid-template-columns: var(--profile-width) minmax(0, 1fr);
+  align-items: start;
+  gap: var(--layout-gap);
+  margin-bottom: 32px;
+}
+
+.profile-photo {
+  width: 100%;
+  max-width: var(--profile-width);
+}
+
+.profile-image {
+  width: 100%;
+  max-width: var(--profile-width);
+  height: auto;
+  border-radius: 14px;
+  object-fit: cover;
+  border: 3px solid #ccc;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.16);
+}
+
+.profile-body {
+  min-width: 0;
+}
+
+/* Responsive content and media */
+img,
+iframe,
+video,
+embed,
+object {
+  max-width: 100%;
+  height: auto;
+}
+
+figure {
+  max-width: 100%;
+  margin: 0;
+}
+
+/* Utility grids */
+.flex-grid,
+.grid,
+.columns,
+.row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 1024px) {
+  .nav-inner {
+    gap: 12px;
+  }
+
+  .content-inner {
+    padding: 28px clamp(16px, 6vw, 28px) 64px;
+  }
+}
+
+@media (max-width: 900px) {
+  .profile-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-photo {
+    max-width: 240px;
+    margin: 0 auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .nav-links {
+    gap: 8px;
+  }
+
+  .content-inner {
+    padding: 24px clamp(14px, 6vw, 24px) 52px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a custom default layout with a full-width navigation bar and shared content container
- update global styling for wider responsive containers and a two-column profile hero that stacks on small screens
- remove duplicated inline navigation from the home page and attach front matter so the shared layout applies sitewide

## Testing
- Not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bccbf6b508330a9704fc5dad6e1b6)