### PR TITLE
Add modal resume viewer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
                 {% endif %}
               {% endfor %}
               <li>
-                <a class="page-link" href="{{ '/assets/TanvirResume.pdf' | relative_url }}" target="_blank" rel="noopener noreferrer">Resume</a>
+                <button class="page-link resume-trigger" type="button" data-resume-src="{{ '/assets/TanvirResume.pdf' | relative_url }}">Resume</button>
               </li>
             </ul>
           </div>
@@ -32,6 +32,71 @@
           {{ content }}
         </div>
       </main>
+      <div class="resume-modal" id="resume-modal" aria-hidden="true">
+        <div class="resume-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="resume-modal-title">
+          <div class="resume-modal__header">
+            <h2 class="resume-modal__title" id="resume-modal-title">Resume</h2>
+            <button type="button" class="resume-modal__close" aria-label="Close resume viewer">
+              &times;
+            </button>
+          </div>
+          <div class="resume-modal__body">
+            <iframe id="resume-frame" title="Resume PDF" loading="lazy"></iframe>
+          </div>
+        </div>
+      </div>
     </div>
+    <script>
+      (function () {
+        const trigger = document.querySelector('.resume-trigger');
+        const modal = document.getElementById('resume-modal');
+        const closeButton = modal?.querySelector('.resume-modal__close');
+        const iframe = document.getElementById('resume-frame');
+        let lastFocused;
+
+        function handleKeydown(event) {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            closeModal();
+          }
+        }
+
+        function openModal() {
+          if (!modal) return;
+          lastFocused = document.activeElement;
+          const resumeSrc = trigger?.dataset.resumeSrc;
+          if (resumeSrc && iframe && !iframe.src) {
+            iframe.src = resumeSrc;
+          }
+          modal.classList.add('is-open');
+          modal.setAttribute('aria-hidden', 'false');
+          document.body.classList.add('modal-open');
+          closeButton?.focus({ preventScroll: true });
+          document.addEventListener('keydown', handleKeydown);
+        }
+
+        function closeModal() {
+          if (!modal) return;
+          modal.classList.remove('is-open');
+          modal.setAttribute('aria-hidden', 'true');
+          document.body.classList.remove('modal-open');
+          if (iframe) {
+            iframe.src = '';
+          }
+          document.removeEventListener('keydown', handleKeydown);
+          if (lastFocused instanceof HTMLElement) {
+            lastFocused.focus({ preventScroll: true });
+          }
+        }
+
+        trigger?.addEventListener('click', openModal);
+        closeButton?.addEventListener('click', closeModal);
+        modal?.addEventListener('click', (event) => {
+          if (event.target === modal) {
+            closeModal();
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -8,6 +8,7 @@
   --page-padding: clamp(18px, 4vw, 36px);
   --layout-gap: clamp(32px, 4vw, 48px);
   --profile-width: clamp(280px, 30vw, 320px);
+  --nav-padding: 12px;
 }
 
 body {
@@ -42,7 +43,7 @@ body {
 .nav-inner {
   max-width: var(--page-max);
   margin: 0 auto;
-  padding: 12px var(--page-padding);
+  padding: var(--nav-padding) var(--page-padding) calc(var(--nav-padding) * 5);
   display: flex;
   align-items: center;
   gap: 16px;
@@ -68,6 +69,10 @@ body {
   font-weight: 600;
   color: #343434;
   text-decoration: none;
+  border: none;
+  background: #ffffff;
+  cursor: pointer;
+  appearance: none;
   padding: 10px 18px;
   border-radius: 6px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
@@ -147,6 +152,92 @@ figure {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 16px;
+}
+
+/* Resume modal */
+.resume-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 4vw, 24px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1000;
+}
+
+.resume-modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.resume-modal__dialog {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 38px rgba(0, 0, 0, 0.18);
+  width: min(1100px, 100%);
+  max-height: min(900px, 90vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.resume-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.resume-modal__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.resume-modal__close {
+  border: none;
+  background: #f2f2f2;
+  color: #343434;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  font-size: 22px;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.resume-modal__close:hover,
+.resume-modal__close:focus {
+  background: #6a5acd;
+  color: #ffffff;
+}
+
+.resume-modal__body {
+  padding: 0;
+  background: #f8f8f8;
+  flex: 1;
+}
+
+.resume-modal__body iframe {
+  border: none;
+  width: 100%;
+  height: 80vh;
+  max-height: min(800px, 80vh);
+  display: block;
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- replace the navigation Resume link with an in-page modal trigger
- add modal markup, script, and styling to display the PDF without opening a new tab

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: Could not locate Gemfile or .bundle/ directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be1acec448330883c31ec2a4f2829)