### PR TITLE
Ensure solid navigation background and active link styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,11 +13,11 @@
         <nav class="site-nav-bar">
           <div class="nav-inner">
             <ul class="nav-links">
-              <li><a class="page-link" href="{{ '/' | relative_url }}">About</a></li>
+              <li><a class="page-link{% if page.url == '/' or page.url == '/index.html' %} is-active{% endif %}" href="{{ '/' | relative_url }}">About</a></li>
               {% for path in site.header_pages %}
                 {% assign my_page = site.pages | where: "path", path | first %}
                 {% if my_page %}
-                  <li><a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a></li>
+                  <li><a class="page-link{% if page.url == my_page.url %} is-active{% endif %}" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a></li>
                 {% endif %}
               {% endfor %}
               <li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -38,6 +38,10 @@ body {
 .site-header {
   width: 100%;
   margin: 0 auto;
+  position: sticky;
+  top: 0;
+  z-index: 200;
+  background: #ffffff;
 }
 
 .nav-inner {
@@ -50,6 +54,7 @@ body {
   flex-wrap: wrap;
   justify-content: center;
   box-sizing: border-box;
+  background: #ffffff;
 }
 
 .nav-links {
@@ -83,6 +88,13 @@ body {
   min-width: 110px;
 }
 
+.nav-links .page-link.is-active,
+.nav-links .page-link.is-active:focus,
+.nav-links .page-link.is-active:hover {
+  background: #f2eefc;
+  color: #343434;
+}
+
 .nav-links .page-link:hover,
 .nav-links .page-link:focus {
   background: #6a5acd;
@@ -108,7 +120,7 @@ body {
   grid-template-columns: var(--profile-width) minmax(0, 1fr);
   align-items: start;
   gap: var(--layout-gap);
-  padding-top: clamp(16px, 3vw, 32px);
+  padding-top: clamp(32px, 6vw, 72px);
   margin-bottom: 32px;
 }
 


### PR DESCRIPTION
## Summary
- make the site header use a solid white background while keeping it fixed at the top
- ensure the navigation container inherits the solid background to prevent underlying content showing through
- highlight the active navigation item with a subtle light purple background across all pages
- increase the about page hero padding to add breathing room below the navigation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be7f947e48330b3135ea69f4ac85f)