### PR TITLE
Revamp About hero and unify primary color

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ layout: default
   .active-menu {
   font-size: 12px;
   color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #6A5ACD;
+  background-color: #3680E8;
   text-decoration: none;
   padding: 9px 15px;
   border-radius: 4px;
@@ -20,13 +20,13 @@ layout: default
 }
 
 .active-menu:hover {
-  background-color: #5548c8; /* ✅ Slightly darker shade on hover */
+  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
 }
   
-  a{color:#6A5ACD;}
+  a{color:#3680E8;}
   /* CSS styles for hover effect */
   a:hover {
-    background-color: #6A5ACD; /* Blue background on hover */
+    background-color: #3680E8; /* Blue background on hover */
     color: white; /* White text on hover */
   }
 
@@ -49,19 +49,19 @@ layout: default
     height: 100%; /* Ensure the link fills the parent's height */
   }
     .urls {
-      color: #6A5ACD;
+      color: #3680E8;
     }
     .urls:hover {
       background-color: #ffffff;
-      color: #6A5ACD;
+      color: #3680E8;
       font-weight:normal;
     }
 
   .news-year {
-    border: 1px solid #e4e3f7;
+    border: 1px solid #d9e6fb;
     border-radius: 6px;
     margin-bottom: 12px;
-    background-color: #f8f8ff;
+    background-color: #f4f8ff;
   }
 
   .news-year summary {
@@ -77,7 +77,7 @@ layout: default
   }
 
   .news-year[open] summary {
-    background-color: #6A5ACD;
+    background-color: #3680E8;
     color: #ffffff;
     border-radius: 6px 6px 0 0;
   }
@@ -107,7 +107,7 @@ layout: default
 
 
 <!-- Add the button here -->
-<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 
 <script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,6 +4,7 @@
 @import "{{ site.theme }}";
 
 :root {
+  --primary-color: #3680e8;
   --page-max: 1380px;
   --page-padding: clamp(18px, 4vw, 36px);
   --layout-gap: clamp(32px, 4vw, 48px);
@@ -22,6 +23,8 @@ body {
   overflow-x: hidden;
   font-family: "Open Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #343434;
+  background: linear-gradient(135deg, rgba(51, 167, 226, 0.06), rgba(72, 54, 182, 0.04));
+  min-height: 100vh;
 }
 
 .wrapper {
@@ -100,13 +103,13 @@ body {
 .nav-links .page-link.is-active,
 .nav-links .page-link.is-active:focus,
 .nav-links .page-link.is-active:hover {
-  background: #f2eefc;
+  background: rgba(54, 128, 232, 0.12);
   color: #343434;
 }
 
 .nav-links .page-link:hover,
 .nav-links .page-link:focus {
-  background: #6a5acd;
+  background: var(--primary-color);
   color: #ffffff;
 }
 
@@ -239,8 +242,114 @@ figure {
 
 .resume-modal__close:hover,
 .resume-modal__close:focus {
-  background: #6a5acd;
+  background: var(--primary-color);
   color: #ffffff;
+}
+
+/* About hero */
+.about-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  align-items: center;
+  gap: clamp(28px, 5vw, 64px);
+  padding-top: clamp(24px, 6vw, 72px);
+  margin-bottom: clamp(20px, 4vw, 48px);
+}
+
+.hero-left {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero-greeting {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #1f3b64;
+}
+
+.hero-title {
+  margin: 0;
+  font-size: clamp(36px, 5vw, 52px);
+  font-weight: 800;
+  color: #111827;
+}
+
+.role-badge {
+  align-self: flex-start;
+  background: var(--primary-color);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+}
+
+.hero-description {
+  margin: 0;
+  font-size: 15px;
+  line-height: 1.7;
+  color: #2f3c4f;
+  max-width: 660px;
+}
+
+.skill-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.skill-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(54, 128, 232, 0.12);
+  color: #1f4f9c;
+  font-size: 13px;
+  font-weight: 700;
+  border: 1px solid rgba(54, 128, 232, 0.18);
+  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+}
+
+.hero-right {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.portrait-wrapper {
+  position: relative;
+  width: clamp(260px, 34vw, 360px);
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+}
+
+.portrait-blob {
+  position: absolute;
+  inset: 12%;
+  background: radial-gradient(circle at 30% 30%, #ffd7c2 0%, #f6bfa1 55%, #f0ad8b 100%);
+  filter: drop-shadow(0 18px 40px rgba(240, 173, 139, 0.28));
+  border-radius: 56% 44% 60% 40% / 46% 55% 45% 54%;
+  z-index: 1;
+}
+
+.portrait-image {
+  position: relative;
+  z-index: 2;
+  width: 78%;
+  height: 78%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 6px solid #ffffff;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.18);
 }
 
 .resume-modal__body {
@@ -272,13 +381,22 @@ body.modal-open {
 }
 
 @media (max-width: 900px) {
-  .profile-hero {
+  .profile-hero,
+  .about-hero {
     grid-template-columns: 1fr;
   }
 
   .profile-photo {
     max-width: 240px;
     margin: 0 auto;
+  }
+
+  .hero-left {
+    order: 1;
+  }
+
+  .hero-right {
+    order: 2;
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ layout: default
   .active-menu {
   font-size: 12px;
   color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #6A5ACD;
+  background-color: #3680E8;
   text-decoration: none;
   padding: 9px 15px;
   border-radius: 4px;
@@ -20,13 +20,13 @@ layout: default
 }
 
 .active-menu:hover {
-  background-color: #5548c8; /* ✅ Slightly darker shade on hover */
+  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
 }
-  
-  a{color:#6A5ACD;}
+
+  a{color:#3680E8;}
   /* CSS styles for hover effect */
   a:hover {
-    background-color: #6A5ACD; /* Blue background on hover */
+    background-color: #3680E8; /* Blue background on hover */
     color: white; /* White text on hover */
   }
 
@@ -49,19 +49,19 @@ layout: default
     height: 100%; /* Ensure the link fills the parent's height */
   }
     .urls {
-      color: #6A5ACD;
+      color: #3680E8;
     }
     .urls:hover {
       background-color: #ffffff;
-      color: #6A5ACD;
+      color: #3680E8;
       font-weight:normal;
     }
 
   .news-year {
-    border: 1px solid #e4e3f7;
+    border: 1px solid #d9e6fb;
     border-radius: 6px;
     margin-bottom: 12px;
-    background-color: #f8f8ff;
+    background-color: #f4f8ff;
   }
 
   .news-year summary {
@@ -77,7 +77,7 @@ layout: default
   }
 
   .news-year[open] summary {
-    background-color: #6A5ACD;
+    background-color: #3680E8;
     color: #ffffff;
     border-radius: 6px 6px 0 0;
   }
@@ -107,7 +107,7 @@ layout: default
 
 
 <!-- Add the button here -->
-<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+  <button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 
 <script>
@@ -131,20 +131,31 @@ window.onscroll = function() {
 
 
 
-<div class="profile-hero">
-  <div class="profile-photo">
-    <img src="{{ site.logo | relative_url }}" alt="Portrait of Md Tanvir Islam" class="profile-image" />
+
+<section class="about-hero">
+  <div class="hero-left">
+    <p class="hero-greeting">Hello!</p>
+    <h1 class="hero-title">This is Tanvir Islam</h1>
+    <button class="role-badge" type="button">Data Analyst</button>
+    <p class="hero-description">
+      Doctoral research fellow focused on data-driven problem solving and impactful storytelling. I blend analytics,
+      dashboards, and databases to uncover insights, influence decisions, and build practical solutions for teams and clients.
+    </p>
+    <div class="skill-pills">
+      <span class="skill-pill">Power BI</span>
+      <span class="skill-pill">Excel</span>
+      <span class="skill-pill">MySQL</span>
+      <span class="skill-pill">Tableau</span>
+    </div>
   </div>
-  <div class="profile-body">
-    <h2 style=" font-size:18px; margin-top: 0; color:#343434;"><strong>Md Tanvir Islam</strong><br>
-    </h2>
-      <p style= "font-size:14px; color:#343434;">
-        Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class= "urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class= "urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class= "urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS). Based on his excellent academic and research performance, he was awarded the <i>``Academic Excellence Award Winner''</i> in 2024 by the NIIED, Government of South Korea. Currently, research assistant at VIS2KNOW Lab he is focusing on multiple emerging topics such as image dehazing, image enhancement, invisible watermarking, marked by several research outcomes published in high impactful conferences and journals such as <i><strong>WACV'26, ICCV'25, CIKM'25, WWW'25, ACM MM'24, ACCV'24, Alexandria Engineering Journal and Engineering Application of Artificial Intelligence</strong></i>. Md Tanvir Islam's passion for innovative applications of computer science and artificial intelligence is evident through his <a class= "urls" href="https://tanvirnwu.github.io/pages/publications" target="_blank">research outcomes</a> published at reputable venues.
-        <br>
-      </p>
+  <div class="hero-right">
+    <div class="portrait-wrapper">
+      <div class="portrait-blob" aria-hidden="true"></div>
+      <img src="{{ site.logo | relative_url }}" alt="Portrait of Md Tanvir Islam" class="portrait-image" />
+    </div>
   </div>
-</div>
-  <hr>
+</section>
+<hr>
 
 
 

--- a/pages/datasets.md
+++ b/pages/datasets.md
@@ -9,7 +9,7 @@ permalink: /pages/datasets
 .active-menu {
   font-size: 12px;
   color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #6A5ACD;
+  background-color: #3680E8;
   text-decoration: none;
   padding: 9px 15px;
   border-radius: 4px;
@@ -23,14 +23,14 @@ permalink: /pages/datasets
 }
 
 .active-menu:hover {
-  background-color: #5548c8; /* ✅ Slightly darker shade on hover */
+  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
 }
 
   
-  a{color:#6A5ACD;}
+  a{color:#3680E8;}
   /* CSS styles for hover effect */
   a:hover {
-    background-color: #6A5ACD; /* Blue background on hover */
+    background-color: #3680E8; /* Blue background on hover */
     color: white; /* White text on hover */
   }
 
@@ -48,10 +48,10 @@ permalink: /pages/datasets
     height: 100%; /* Ensure the link fills the parent's height */
   }
     .urls {
-      color: #6A5ACD;
+      color: #3680E8;
     }
     .urls:hover {
-      background-color: #6A5ACD;
+      background-color: #3680E8;
       color: white;
       font-weight:normal;
     }
@@ -59,10 +59,10 @@ permalink: /pages/datasets
   .bibtex-container {
     margin-top: -30px;
     margin-bottom: 3px;
-  background-color: #E2E3F4;
+  background-color: #dde9fb;
   font-size: 10px;
   color:#343434;
-  border-left: 4px solid #6A5ACD;
+  border-left: 4px solid #3680E8;
   font-family: monospace;
   padding: 6px;
   white-space: pre-wrap;
@@ -81,7 +81,7 @@ permalink: /pages/datasets
 
 .toggle-button {
   cursor: pointer;
-  color: #6A5ACD;  /* ✅ Default color */
+  color: #3680E8;  /* ✅ Default color */
   text-decoration: none;
   font-weight: bold;
   transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
@@ -89,14 +89,14 @@ permalink: /pages/datasets
 }
 
 .toggle-button:hover {
-  color: #6A5ACD !important;  /* ✅ Turns white on hover */
+  color: #3680E8 !important;  /* ✅ Turns white on hover */
   background-color: white;  /* ✅ Adds a background on hover for visibility */
   text-decoration: none;  /* ✅ Prevents underline on hover */
 }
 
 /* ✅ Ensures the color stays unchanged after clicking */
 .toggle-button:focus, .toggle-button:active {
-  color: #6A5ACD !important;
+  color: #3680E8 !important;
   outline: none;
 }
 
@@ -119,7 +119,7 @@ permalink: /pages/datasets
     }
 
     // ✅ Ensure the link color does not change after clicking
-    link.style.color = "#6A5ACD";
+    link.style.color = "#3680E8";
   }
 </script>
 
@@ -128,7 +128,7 @@ permalink: /pages/datasets
 
 
 <!--
-<h3 style="margin-top: 70px; color: #267CB9;">Image Enhancement</h3>
+<h3 style="margin-top: 70px; color: #3680E8;">Image Enhancement</h3>
 <hr> -->
 
 

--- a/pages/projects.md
+++ b/pages/projects.md
@@ -6,17 +6,17 @@ permalink: /pages/projects
 
 <style>
   .urls {
-      color: #6A5ACD;
+      color: #3680E8;
     }
     .urls:hover {
       background-color: #ffffff;
-      color: #6A5ACD;
+      color: #3680E8;
       font-weight:normal;
     }
 
   /* CSS styles for hover effect */
   a:hover {
-    background-color: #6A5ACD; /* Blue background on hover */
+    background-color: #3680E8; /* Blue background on hover */
     color: white; /* White text on hover */
   }
 
@@ -29,7 +29,7 @@ permalink: /pages/projects
     padding: 0; /* Remove padding from list items */
   }
 
-  a {color:#6A5ACD;
+  a {color:#3680E8;
     display: inline-block; /* Make the anchor display as a block to fill its parent */
     height: 100%; /* Ensure the link fills the parent's height */
   }
@@ -47,7 +47,7 @@ permalink: /pages/projects
   }
 
   .custom-button:hover {
-    background-color: #267CB9; /* Blue background on hover (Blue: #0066ff)*/
+    background-color: #3680E8; /* Blue background on hover (Blue: #0066ff)*/
     color: white; /* White text on hover */
   }
 
@@ -57,7 +57,7 @@ permalink: /pages/projects
     text-decoration: none;
     padding: 9px 15px;
     border-radius: 4px;
-     background-color: #267CB9; 
+     background-color: #3680E8; 
     box-shadow: 0 0px 0px rgba(0, 0, 0, 0.0);
     transition: background-color 0.3s, color 0.3s;
     display: block;
@@ -72,7 +72,7 @@ permalink: /pages/projects
 
 
 
-<h3 style="margin-top: 70px; color: #267CB9;">Image Enhancement</h3>
+<h3 style="margin-top: 70px; color: #3680E8;">Image Enhancement</h3>
 <hr>
 
 

--- a/pages/publications.md
+++ b/pages/publications.md
@@ -9,7 +9,7 @@ permalink: /pages/publications
     font-family: Arial, sans-serif;
   }
   .accordion {
-    background-color: #6A5ACD;
+    background-color: #3680E8;
     color: white;
     cursor: pointer;
     padding: 12px;
@@ -24,12 +24,12 @@ permalink: /pages/publications
     box-sizing: border-box;
   }
   .accordion:hover {
-    background-color: #E9E8F9;
-    color: #6A5ACD;
+    background-color: #E6F0FF;
+    color: #3680E8;
   }
   .accordion.active {
-    background-color: #E9E8F9;
-    color: #6A5ACD;
+    background-color: #E6F0FF;
+    color: #3680E8;
   }
   .panel {
     padding: 0 15px;
@@ -60,14 +60,14 @@ permalink: /pages/publications
     margin-left: 5px;
   }
   a {
-    color: #6A5ACD;
+    color: #3680E8;
   }
   .urls {
-    color: #6A5ACD;
+    color: #3680E8;
   }
   .urls:hover {
     background-color: #ffffff;
-    color: #6A5ACD;
+    color: #3680E8;
     font-weight: normal;
   }
   p {
@@ -75,7 +75,7 @@ permalink: /pages/publications
   }
 </style>
 <!-- Add the button here -->
-<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 <script>
 function scrollToPosition() {


### PR DESCRIPTION
## Summary
- rebuild the About page hero with a two-column layout, badges, skill pills, and a circular portrait treatment
- apply a subtle sitewide gradient background and primary blue styling across navigation and hero elements
- update remaining pages and docs to use the 3680E8 primary color for buttons, links, and hover states

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695becc573b48330ae117ca8f966d4d4)