### PR TITLE
Simplify About hero image styling

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -868,12 +868,19 @@ figure {
 .portrait-image {
   width: 100%;
   height: auto;
+  border: none;
   border-radius: 0;
   object-fit: contain;
   box-shadow: none;
   background: transparent;
   position: relative;
   z-index: 1;
+}
+
+.portrait-wrapper::before,
+.portrait-blob {
+  content: none;
+  display: none;
 }
 
 /* About hero */


### PR DESCRIPTION
## Summary
- remove decorative borders and shadows from the About page hero image
- disable decorative pseudo-elements to keep the portrait background-free

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c052a30488330a9b70c3d5f19cae1)