### PR TITLE
Adjust about hero layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -382,7 +382,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -488,7 +488,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -582,7 +582,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -674,7 +674,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -783,7 +783,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -886,7 +886,7 @@ figure {
 /* About hero */
 .about-hero {
   display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+  grid-template-columns: minmax(280px, 0.95fr) minmax(0, 1.05fr);
   align-items: center;
   gap: clamp(28px, 5vw, 64px);
   padding-top: clamp(24px, 6vw, 72px);
@@ -1019,11 +1019,11 @@ body.modal-open {
   }
 
   .hero-left {
-    order: 1;
+    order: 2;
   }
 
   .hero-right {
-    order: 2;
+    order: 1;
   }
 }
 

--- a/index.md
+++ b/index.md
@@ -133,6 +133,11 @@ window.onscroll = function() {
 
 
 <section class="about-hero">
+  <div class="hero-right">
+    <div class="portrait-wrapper">
+      <img src="{{ site.logo | relative_url }}" alt="Portrait of Md Tanvir Islam" class="portrait-image" />
+    </div>
+  </div>
   <div class="hero-left">
     <p class="hero-greeting">Hello!</p>
     <h1 class="hero-title">This is Tanvir Islam</h1>
@@ -146,11 +151,6 @@ window.onscroll = function() {
       <span class="skill-pill">Excel</span>
       <span class="skill-pill">MySQL</span>
       <span class="skill-pill">Tableau</span>
-    </div>
-  </div>
-  <div class="hero-right">
-    <div class="portrait-wrapper">
-      <img src="{{ site.logo | relative_url }}" alt="Portrait of Md Tanvir Islam" class="portrait-image" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- reorder the About hero markup so the portrait appears to the left of the text
- update layout columns and responsive ordering to keep text on the right and image first when stacked

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c067c8d0883308da74996e898c83b)