### PR TITLE
Refactor navigation and contact modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,16 @@ layout: default
 ---
 
 <style>
-  .active-menu {
-  font-size: 12px;
-  color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #3680E8;
-  text-decoration: none;
-  padding: 9px 15px;
-  border-radius: 4px;
-  box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1);
-  transition: background-color 0.3s, color 0.3s;
-  display: block;
-}
-
-.active-menu strong {
-  color: white !important; /* ✅ Forces text inside <strong> to be white */
-}
-
-.active-menu:hover {
-  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
-}
-  
-  a{color:#3680E8;}
-  /* CSS styles for hover effect */
-  a:hover {
-    background-color: #3680E8; /* Blue background on hover */
-    color: white; /* White text on hover */
+  a {
+    color: #6A5ACD;
+    text-decoration: none;
   }
 
-  a:hover strong {
-    color: white; /* Ensure bold text inside links also turns white */
+  a:hover,
+  a:focus {
+    color: #554cbf;
+    text-decoration: underline;
+    background: transparent;
   }
 
   /* Hide the GitHub profile button rendered by the theme header */
@@ -39,29 +20,23 @@ layout: default
     display: none !important;
   }
 
-  li {
-    margin: 0; /* Remove any unnecessary margin */
-    padding: 0; /* Remove padding from list items */
+  .urls {
+    color: #6A5ACD;
   }
 
-  a {
-    display: inline-block; /* Make the anchor display as a block to fill its parent */
-    height: 100%; /* Ensure the link fills the parent's height */
+  .urls:hover,
+  .urls:focus {
+    background-color: transparent;
+    color: #6A5ACD;
+    font-weight: normal;
+    text-decoration: underline;
   }
-    .urls {
-      color: #3680E8;
-    }
-    .urls:hover {
-      background-color: #ffffff;
-      color: #3680E8;
-      font-weight:normal;
-    }
 
   .news-year {
-    border: 1px solid #d9e6fb;
+    border: 1px solid rgba(106, 90, 205, 0.15);
     border-radius: 6px;
     margin-bottom: 12px;
-    background-color: #f4f8ff;
+    background-color: rgba(106, 90, 205, 0.06);
   }
 
   .news-year summary {
@@ -77,7 +52,7 @@ layout: default
   }
 
   .news-year[open] summary {
-    background-color: #3680E8;
+    background-color: #6A5ACD;
     color: #ffffff;
     border-radius: 6px 6px 0 0;
   }
@@ -107,7 +82,7 @@ layout: default
 
 
 <!-- Add the button here -->
-<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 
 <script>
@@ -195,24 +170,3 @@ window.onscroll = function() {
     <li>[Dec 2018] Completed graduation with <strong>1<sup>st</sup> Merit Position</strong> from NWU, Bangladesh.</li>
   </ul>
 </details>
-<hr>
-
-
-<!-- Add the LinkedIn and Google Scholar icons and links -->
-<h3 style="font-size: 14px; color: #343434; margin-top: 40px;">☏ Concat</h3>
-<p style="font-size:13px; color:#343434;">
-  <span style="vertical-align: middle;">
-    <img src="https://cdn-icons-png.flaticon.com/512/732/732200.png" alt="Email" width="18" height="18" style="vertical-align: middle;">
-     tanvirnwu[@]knu.ac.kr
-  </span>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a  class="urls" href="https://www.linkedin.com/in/tanvirnwu/" target="_blank" style="text-decoration: none; color: black;">
-    <img src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="LinkedIn" width="18" height="18" style="vertical-align: middle;">
-    LinkedIn
-  </a>
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <a class="urls" href="https://scholar.google.com/citations?user=UvINe-sAAAAJ&hl=en" target="_blank" style="text-decoration: none; color: black;">
-    <img src="https://images.icon-icons.com/2108/PNG/512/google_scholar_icon_130918.png" alt="Google Scholar" width="18" height="18" style="vertical-align: middle;">
-    Google Scholar
-  </a>
-</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,7 +12,7 @@
       <header class="site-header">
         <nav class="site-nav-bar">
           <div class="nav-inner">
-            <ul class="nav-links">
+            <ul class="nav-links nav-links--left">
               <li><a class="page-link{% if page.url == '/' or page.url == '/index.html' %} is-active{% endif %}" href="{{ '/' | relative_url }}">About</a></li>
               {% for path in site.header_pages %}
                 {% assign my_page = site.pages | where: "path", path | first %}
@@ -22,6 +22,11 @@
               {% endfor %}
               <li>
                 <button class="page-link resume-trigger" type="button" data-resume-src="{{ '/assets/TanvirResume.pdf' | relative_url }}">Resume</button>
+              </li>
+            </ul>
+            <ul class="nav-links nav-links--right">
+              <li>
+                <button class="page-link contact-trigger" type="button">Contact</button>
               </li>
             </ul>
           </div>
@@ -42,6 +47,34 @@
           </div>
           <div class="resume-modal__body">
             <iframe id="resume-frame" title="Resume PDF" loading="lazy"></iframe>
+          </div>
+        </div>
+      </div>
+      <div class="contact-modal" id="contact-modal" aria-hidden="true">
+        <div class="contact-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="contact-modal-title">
+          <div class="contact-modal__header">
+            <h2 class="contact-modal__title" id="contact-modal-title">Contact</h2>
+            <button type="button" class="contact-modal__close" aria-label="Close contact dialog">&times;</button>
+          </div>
+          <div class="contact-modal__body">
+            <ul class="contact-list">
+              <li class="contact-item">
+                <span class="contact-icon" aria-hidden="true">📧</span>
+                <span class="contact-text">tanvirnwu[@]knu.ac.kr</span>
+              </li>
+              <li class="contact-item">
+                <span class="contact-icon" aria-hidden="true">🏛️</span>
+                <span class="contact-text">Brain AI Lab, Kyungpook National University</span>
+              </li>
+              <li class="contact-item">
+                <span class="contact-icon" aria-hidden="true">💼</span>
+                <a class="contact-link" href="https://www.linkedin.com/in/tanvirnwu/" target="_blank" rel="noreferrer noopener">LinkedIn</a>
+              </li>
+              <li class="contact-item">
+                <span class="contact-icon" aria-hidden="true">🎓</span>
+                <a class="contact-link" href="https://scholar.google.com/citations?user=UvINe-sAAAAJ&hl=en" target="_blank" rel="noreferrer noopener">Google Scholar</a>
+              </li>
+            </ul>
           </div>
         </div>
       </div>
@@ -83,6 +116,48 @@
           if (iframe) {
             iframe.src = '';
           }
+          document.removeEventListener('keydown', handleKeydown);
+          if (lastFocused instanceof HTMLElement) {
+            lastFocused.focus({ preventScroll: true });
+          }
+        }
+
+        trigger?.addEventListener('click', openModal);
+        closeButton?.addEventListener('click', closeModal);
+        modal?.addEventListener('click', (event) => {
+          if (event.target === modal) {
+            closeModal();
+          }
+        });
+      })();
+      (function () {
+        const trigger = document.querySelector('.contact-trigger');
+        const modal = document.getElementById('contact-modal');
+        const closeButton = modal?.querySelector('.contact-modal__close');
+        let lastFocused;
+
+        function handleKeydown(event) {
+          if (event.key === 'Escape') {
+            event.preventDefault();
+            closeModal();
+          }
+        }
+
+        function openModal() {
+          if (!modal) return;
+          lastFocused = document.activeElement;
+          modal.classList.add('is-open');
+          modal.setAttribute('aria-hidden', 'false');
+          document.body.classList.add('modal-open');
+          closeButton?.focus({ preventScroll: true });
+          document.addEventListener('keydown', handleKeydown);
+        }
+
+        function closeModal() {
+          if (!modal) return;
+          modal.classList.remove('is-open');
+          modal.setAttribute('aria-hidden', 'true');
+          document.body.classList.remove('modal-open');
           document.removeEventListener('keydown', handleKeydown);
           if (lastFocused instanceof HTMLElement) {
             lastFocused.focus({ preventScroll: true });

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,7 +4,7 @@
 @import "{{ site.theme }}";
 
 :root {
-  --primary-color: #3680e8;
+  --primary-color: #6a5acd;
   --page-max: 1380px;
   --page-padding: clamp(18px, 4vw, 36px);
   --layout-gap: clamp(32px, 4vw, 48px);
@@ -24,7 +24,7 @@ body {
   overflow-x: hidden;
   font-family: "Open Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   color: #343434;
-  background: linear-gradient(135deg, rgba(51, 167, 226, 0.06), rgba(72, 54, 182, 0.04));
+  background: linear-gradient(135deg, rgba(106, 90, 205, 0.08), rgba(106, 90, 205, 0.04));
   min-height: 100vh;
 }
 
@@ -65,7 +65,7 @@ body {
   align-items: center;
   gap: 16px;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: space-between;
   box-sizing: border-box;
   background: transparent;
 }
@@ -73,45 +73,49 @@ body {
 .nav-links {
   display: flex;
   align-items: center;
+  gap: 16px;
   flex-wrap: wrap;
-  gap: 12px;
   list-style: none;
   margin: 0;
   padding: 0;
-  justify-content: center;
-  width: 100%;
+}
+
+.nav-links--left {
+  flex: 1 1 auto;
+  justify-content: flex-start;
+}
+
+.nav-links--right {
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  margin-left: auto;
 }
 
 .nav-links .page-link {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 600;
   color: #343434;
   text-decoration: none;
   border: none;
-  background: #ffffff;
+  background: transparent;
   cursor: pointer;
   appearance: none;
-  padding: 10px 18px;
-  border-radius: 6px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 110px;
+  padding: 0;
+  box-shadow: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
 }
 
 .nav-links .page-link.is-active,
 .nav-links .page-link.is-active:focus,
 .nav-links .page-link.is-active:hover {
-  background: rgba(54, 128, 232, 0.12);
-  color: #343434;
+  color: var(--primary-color);
+  text-decoration: underline;
 }
 
 .nav-links .page-link:hover,
 .nav-links .page-link:focus {
-  background: var(--primary-color);
-  color: #ffffff;
+  color: var(--primary-color);
+  text-decoration: underline;
 }
 
 /* Main content container */
@@ -176,12 +180,19 @@ body {
   gap: 8px;
 }
 
+.contact-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+}
+
 .contact-icon img {
   display: block;
 }
 
 .contact-link {
-  color: #3680E8;
+  color: var(--primary-color);
   text-decoration: none;
 }
 
@@ -314,14 +325,85 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
+}
+
+.contact-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 4vw, 24px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 1000;
+}
+
+.contact-modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.contact-modal__dialog {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 10px 38px rgba(0, 0, 0, 0.18);
+  width: min(520px, 100%);
+  max-height: min(700px, 90vh);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.contact-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid #eaeaea;
+}
+
+.contact-modal__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.contact-modal__close {
+  border: none;
+  background: #f2f2f2;
+  color: #343434;
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  font-size: 22px;
+  font-weight: 700;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.contact-modal__close:hover,
+.contact-modal__close:focus {
+  background: var(--primary-color);
+  color: #ffffff;
+}
+
+.contact-modal__body {
+  padding: 18px 20px 22px;
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -337,12 +419,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -400,7 +482,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -420,14 +502,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -443,12 +525,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -506,7 +588,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -526,14 +608,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -549,12 +631,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -600,7 +682,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -620,14 +702,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -643,12 +725,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -692,7 +774,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -712,14 +794,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -735,12 +817,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -801,7 +883,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -821,14 +903,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -844,12 +926,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -904,7 +986,7 @@ figure {
   font-size: 16px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  color: #1f3b64;
+  color: var(--primary-color);
 }
 
 .hero-title {
@@ -924,14 +1006,14 @@ figure {
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.02em;
-  box-shadow: 0 10px 30px rgba(54, 128, 232, 0.25);
+  box-shadow: 0 10px 30px rgba(106, 90, 205, 0.25);
 }
 
 .hero-description {
   margin: 0;
   font-size: 15px;
   line-height: 1.7;
-  color: #2f3c4f;
+  color: #343434;
   max-width: 660px;
 }
 
@@ -947,12 +1029,12 @@ figure {
   justify-content: center;
   padding: 10px 16px;
   border-radius: 999px;
-  background: rgba(54, 128, 232, 0.12);
-  color: #1f4f9c;
+  background: rgba(106, 90, 205, 0.12);
+  color: var(--primary-color);
   font-size: 13px;
   font-weight: 700;
-  border: 1px solid rgba(54, 128, 232, 0.18);
-  box-shadow: 0 12px 28px rgba(54, 128, 232, 0.08);
+  border: 1px solid rgba(106, 90, 205, 0.18);
+  box-shadow: 0 12px 28px rgba(106, 90, 205, 0.08);
 }
 
 .hero-right {
@@ -1030,6 +1112,15 @@ body.modal-open {
 @media (max-width: 640px) {
   .nav-links {
     gap: 8px;
+  }
+
+  .nav-links--left,
+  .nav-links--right {
+    width: 100%;
+  }
+
+  .nav-links--right {
+    justify-content: flex-end;
   }
 
   .content-inner {

--- a/index.md
+++ b/index.md
@@ -3,35 +3,16 @@ layout: default
 ---
 
 <style>
-  .active-menu {
-  font-size: 12px;
-  color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #3680E8;
-  text-decoration: none;
-  padding: 9px 15px;
-  border-radius: 4px;
-  box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1);
-  transition: background-color 0.3s, color 0.3s;
-  display: block;
-}
-
-.active-menu strong {
-  color: white !important; /* ✅ Forces text inside <strong> to be white */
-}
-
-.active-menu:hover {
-  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
-}
-
-  a{color:#3680E8;}
-  /* CSS styles for hover effect */
-  a:hover {
-    background-color: #3680E8; /* Blue background on hover */
-    color: white; /* White text on hover */
+  a {
+    color: #6A5ACD;
+    text-decoration: none;
   }
 
-  a:hover strong {
-    color: white; /* Ensure bold text inside links also turns white */
+  a:hover,
+  a:focus {
+    color: #554cbf;
+    text-decoration: underline;
+    background: transparent;
   }
 
   /* Hide the GitHub profile button rendered by the theme header */
@@ -39,29 +20,23 @@ layout: default
     display: none !important;
   }
 
-  li {
-    margin: 0; /* Remove any unnecessary margin */
-    padding: 0; /* Remove padding from list items */
+  .urls {
+    color: #6A5ACD;
   }
 
-  a {
-    display: inline-block; /* Make the anchor display as a block to fill its parent */
-    height: 100%; /* Ensure the link fills the parent's height */
+  .urls:hover,
+  .urls:focus {
+    background-color: transparent;
+    color: #6A5ACD;
+    font-weight: normal;
+    text-decoration: underline;
   }
-    .urls {
-      color: #3680E8;
-    }
-    .urls:hover {
-      background-color: #ffffff;
-      color: #3680E8;
-      font-weight:normal;
-    }
 
   .news-year {
-    border: 1px solid #d9e6fb;
+    border: 1px solid rgba(106, 90, 205, 0.15);
     border-radius: 6px;
     margin-bottom: 12px;
-    background-color: #f4f8ff;
+    background-color: rgba(106, 90, 205, 0.06);
   }
 
   .news-year summary {
@@ -77,7 +52,7 @@ layout: default
   }
 
   .news-year[open] summary {
-    background-color: #3680E8;
+    background-color: #6A5ACD;
     color: #ffffff;
     border-radius: 6px 6px 0 0;
   }
@@ -107,7 +82,7 @@ layout: default
 
 
 <!-- Add the button here -->
-  <button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+  <button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 
 <script>
@@ -203,28 +178,4 @@ window.onscroll = function() {
       <li>[Dec 2018] Completed graduation with <strong>1<sup>st</sup> Merit Position</strong> from NWU, Bangladesh.</li>
     </ul>
   </details>
-</section>
-<section class="contact-section">
-  <hr>
-  <h3 class="contact-heading">☏ Contact</h3>
-  <ul class="contact-list">
-    <li class="contact-item">
-      <span class="contact-icon" aria-hidden="true">
-        <img src="https://cdn-icons-png.flaticon.com/512/732/732200.png" alt="" width="18" height="18">
-      </span>
-      <span class="contact-text">tanvirnwu[@]knu.ac.kr</span>
-    </li>
-    <li class="contact-item">
-      <span class="contact-icon" aria-hidden="true">
-        <img src="https://cdn-icons-png.flaticon.com/512/174/174857.png" alt="" width="18" height="18">
-      </span>
-      <a class="contact-link" href="https://www.linkedin.com/in/tanvirnwu/" target="_blank" rel="noreferrer noopener">LinkedIn</a>
-    </li>
-    <li class="contact-item">
-      <span class="contact-icon" aria-hidden="true">
-        <img src="https://images.icon-icons.com/2108/PNG/512/google_scholar_icon_130918.png" alt="" width="18" height="18">
-      </span>
-      <a class="contact-link" href="https://scholar.google.com/citations?user=UvINe-sAAAAJ&hl=en" target="_blank" rel="noreferrer noopener">Google Scholar</a>
-    </li>
-  </ul>
 </section>

--- a/pages/datasets.md
+++ b/pages/datasets.md
@@ -6,63 +6,37 @@ permalink: /pages/datasets
 
 <style>
 
-.active-menu {
-  font-size: 12px;
-  color: white !important;  /* ✅ Forces text color to stay white */
-  background-color: #3680E8;
+a {
+  color:#6A5ACD;
   text-decoration: none;
-  padding: 9px 15px;
-  border-radius: 4px;
-  box-shadow: 0 2px 25px rgba(0, 0, 0, 0.1);
-  transition: background-color 0.3s, color 0.3s;
-  display: block;
 }
 
-.active-menu strong {
-  color: white !important; /* ✅ Forces text inside <strong> to be white */
+a:hover,
+a:focus {
+  color: #554cbf;
+  text-decoration: underline;
+  background: transparent;
 }
 
-.active-menu:hover {
-  background-color: #2f6ac6; /* ✅ Slightly darker shade on hover */
+.urls {
+  color: #6A5ACD;
 }
 
-  
-  a{color:#3680E8;}
-  /* CSS styles for hover effect */
-  a:hover {
-    background-color: #3680E8; /* Blue background on hover */
-    color: white; /* White text on hover */
-  }
-
-  a:hover strong {
-    color: white; /* Ensure bold text inside links also turns white */
-  }
-
-  li {
-    margin: 0; /* Remove any unnecessary margin */
-    padding: 0; /* Remove padding from list items */
-  }
-
-  a {
-    display: inline-block; /* Make the anchor display as a block to fill its parent */
-    height: 100%; /* Ensure the link fills the parent's height */
-  }
-    .urls {
-      color: #3680E8;
-    }
-    .urls:hover {
-      background-color: #3680E8;
-      color: white;
-      font-weight:normal;
-    }
+.urls:hover,
+.urls:focus {
+  background-color: transparent;
+  color: #6A5ACD;
+  font-weight:normal;
+  text-decoration: underline;
+}
 
   .bibtex-container {
     margin-top: -30px;
     margin-bottom: 3px;
-  background-color: #dde9fb;
+  background-color: rgba(106, 90, 205, 0.1);
   font-size: 10px;
   color:#343434;
-  border-left: 4px solid #3680E8;
+  border-left: 4px solid #6A5ACD;
   font-family: monospace;
   padding: 6px;
   white-space: pre-wrap;
@@ -81,7 +55,7 @@ permalink: /pages/datasets
 
 .toggle-button {
   cursor: pointer;
-  color: #3680E8;  /* ✅ Default color */
+  color: #6A5ACD;  /* ✅ Default color */
   text-decoration: none;
   font-weight: bold;
   transition: color 0.3s ease-in-out, background-color 0.3s ease-in-out;
@@ -89,14 +63,14 @@ permalink: /pages/datasets
 }
 
 .toggle-button:hover {
-  color: #3680E8 !important;  /* ✅ Turns white on hover */
-  background-color: white;  /* ✅ Adds a background on hover for visibility */
-  text-decoration: none;  /* ✅ Prevents underline on hover */
+  color: #554cbf !important;
+  background-color: transparent;
+  text-decoration: underline;
 }
 
 /* ✅ Ensures the color stays unchanged after clicking */
 .toggle-button:focus, .toggle-button:active {
-  color: #3680E8 !important;
+  color: #6A5ACD !important;
   outline: none;
 }
 
@@ -119,7 +93,7 @@ permalink: /pages/datasets
     }
 
     // ✅ Ensure the link color does not change after clicking
-    link.style.color = "#3680E8";
+    link.style.color = "#6A5ACD";
   }
 </script>
 
@@ -128,7 +102,7 @@ permalink: /pages/datasets
 
 
 <!--
-<h3 style="margin-top: 70px; color: #3680E8;">Image Enhancement</h3>
+<h3 style="margin-top: 70px; color: #6A5ACD;">Image Enhancement</h3>
 <hr> -->
 
 

--- a/pages/projects.md
+++ b/pages/projects.md
@@ -6,17 +6,17 @@ permalink: /pages/projects
 
 <style>
   .urls {
-      color: #3680E8;
+      color: #6A5ACD;
     }
     .urls:hover {
       background-color: #ffffff;
-      color: #3680E8;
+      color: #6A5ACD;
       font-weight:normal;
     }
 
   /* CSS styles for hover effect */
   a:hover {
-    background-color: #3680E8; /* Blue background on hover */
+    background-color: #6A5ACD; /* Primary background on hover */
     color: white; /* White text on hover */
   }
 
@@ -29,7 +29,7 @@ permalink: /pages/projects
     padding: 0; /* Remove padding from list items */
   }
 
-  a {color:#3680E8;
+  a {color:#6A5ACD;
     display: inline-block; /* Make the anchor display as a block to fill its parent */
     height: 100%; /* Ensure the link fills the parent's height */
   }
@@ -47,7 +47,7 @@ permalink: /pages/projects
   }
 
   .custom-button:hover {
-    background-color: #3680E8; /* Blue background on hover (Blue: #0066ff)*/
+    background-color: #6A5ACD; /* Primary background on hover */
     color: white; /* White text on hover */
   }
 
@@ -57,7 +57,7 @@ permalink: /pages/projects
     text-decoration: none;
     padding: 9px 15px;
     border-radius: 4px;
-     background-color: #3680E8; 
+     background-color: #6A5ACD; 
     box-shadow: 0 0px 0px rgba(0, 0, 0, 0.0);
     transition: background-color 0.3s, color 0.3s;
     display: block;
@@ -65,14 +65,14 @@ permalink: /pages/projects
   }
 
   .button:hover {
-    background-color: white; /* Blue background on hover (Blue: #0066ff)*/
-    color: black; /* White text on hover */
+    background-color: white; /* Primary hover contrast */
+    color: black; /* Text on hover */
   }
 </style>
 
 
 
-<h3 style="margin-top: 70px; color: #3680E8;">Image Enhancement</h3>
+<h3 style="margin-top: 70px; color: #6A5ACD;">Image Enhancement</h3>
 <hr>
 
 

--- a/pages/publications.md
+++ b/pages/publications.md
@@ -9,7 +9,7 @@ permalink: /pages/publications
     font-family: Arial, sans-serif;
   }
   .accordion {
-    background-color: #3680E8;
+    background-color: #6A5ACD;
     color: white;
     cursor: pointer;
     padding: 12px;
@@ -24,12 +24,12 @@ permalink: /pages/publications
     box-sizing: border-box;
   }
   .accordion:hover {
-    background-color: #E6F0FF;
-    color: #3680E8;
+    background-color: rgba(106, 90, 205, 0.12);
+    color: #6A5ACD;
   }
   .accordion.active {
-    background-color: #E6F0FF;
-    color: #3680E8;
+    background-color: rgba(106, 90, 205, 0.12);
+    color: #6A5ACD;
   }
   .panel {
     padding: 0 15px;
@@ -60,14 +60,14 @@ permalink: /pages/publications
     margin-left: 5px;
   }
   a {
-    color: #3680E8;
+    color: #6A5ACD;
   }
   .urls {
-    color: #3680E8;
+    color: #6A5ACD;
   }
   .urls:hover {
     background-color: #ffffff;
-    color: #3680E8;
+    color: #6A5ACD;
     font-weight: normal;
   }
   p {
@@ -75,7 +75,7 @@ permalink: /pages/publications
   }
 </style>
 <!-- Add the button here -->
-<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #3680E8; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
+<button id="scrollButton" onclick="scrollToPosition()" style="position: fixed; bottom: 20px; right: 20px; padding: 10px 20px; background-color: #6A5ACD; color: white; border: none; border-radius: 5px; cursor: pointer;">&#8593;</button>
 
 <script>
 function scrollToPosition() {


### PR DESCRIPTION
## Summary
- restyle navigation links as text-only, align core pages left, and place the new Contact trigger on the right
- add a Contact modal containing email, affiliation, and profile links while removing the inline About-page contact block
- unify site accents under the 6A5ACD primary color across layout, components, and content pages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c0970f25083308f506c28d5ba5efd)