### PR TITLE
Move hero background decorations to global layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -27,6 +27,58 @@ body {
   color: #343434;
   background: #ffffff;
   min-height: 100vh;
+  position: relative;
+  z-index: 0;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  pointer-events: none;
+  z-index: 0;
+  background-repeat: no-repeat;
+  background-size: contain;
+  display: block;
+}
+
+body::before {
+  background-image: url('/assets/left_bg.png');
+  width: 42vw;
+  max-width: 360px;
+  height: 50vw;
+  max-height: 460px;
+  top: clamp(360px, 42vh, 540px);
+  left: max(-140px, -14vw);
+}
+
+body::after {
+  background-image: url('/assets/right_bg.png');
+  width: 42vw;
+  max-width: 360px;
+  height: 48vw;
+  max-height: 420px;
+  top: clamp(400px, 48vh, 580px);
+  right: max(-140px, -14vw);
+}
+
+@media (max-width: 768px) {
+  body::before,
+  body::after {
+    width: 72vw;
+    height: 72vw;
+    opacity: 0.35;
+  }
+
+  body::before {
+    top: clamp(320px, 46vh, 520px);
+    left: max(-120px, -18vw);
+  }
+
+  body::after {
+    top: clamp(360px, 54vh, 560px);
+    right: max(-120px, -18vw);
+  }
 }
 
 .wrapper {
@@ -36,6 +88,8 @@ body {
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
+  position: relative;
+  z-index: 1;
 }
 
 /* Full-width navigation with constrained inner content */
@@ -496,77 +550,6 @@ figure {
   row-gap: clamp(16px, 3vw, 24px);
   padding-top: clamp(24px, 6vw, 72px);
   margin-bottom: clamp(20px, 4vw, 48px);
-  position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  background: #ffffff;
-}
-
-.about-hero > * {
-  position: relative;
-  z-index: 1;
-}
-
-.about-hero::before,
-.about-hero::after {
-  content: "";
-  position: absolute;
-  pointer-events: none;
-  z-index: 0;
-  background-repeat: no-repeat;
-  background-size: contain;
-  display: block;
-}
-
-.about-hero::before {
-  background-image: url('/assets/left_bg.png');
-  width: 42vw;
-  max-width: 360px;
-  height: 50vw;
-  max-height: 460px;
-  top: -48px;
-  left: -12vw;
-}
-
-.about-hero::after {
-  background-image: url('/assets/right_bg.png');
-  width: 42vw;
-  max-width: 360px;
-  height: 48vw;
-  max-height: 420px;
-  top: 12px;
-  right: -10vw;
-}
-
-@media (min-width: 1167px) {
-  .about-hero::before {
-    left: -140px;
-  }
-}
-
-@media (min-width: 1400px) {
-  .about-hero::after {
-    right: -140px;
-  }
-}
-
-@media (max-width: 768px) {
-  .about-hero::before,
-  .about-hero::after {
-    width: 72vw;
-    height: 72vw;
-    opacity: 0.35;
-  }
-
-  .about-hero::before {
-    top: -32px;
-    left: -24vw;
-  }
-
-  .about-hero::after {
-    top: 28px;
-    right: -22vw;
-  }
 }
 
 .hero-left {


### PR DESCRIPTION
## Summary
- move the decorative background assets from the hero container to fixed body-level pseudo elements
- adjust positioning so the left and right backgrounds sit just below the hero while staying behind all content
- ensure the main wrapper layers above the decorations while preserving the white page background across pages

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd168c0f48330b041614fd8f3e7f3)