### PR TITLE
Refine hero read more interaction

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -644,31 +644,40 @@ figure {
   z-index: 1;
 }
 
+
 .hero-description-block {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  position: relative;
 }
-.hero-description--clamped {
+
+.hero-description {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.hero-description__text {
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   max-height: calc(1.7em * 3);
+  padding-right: 68px;
 }
 
 @supports not (-webkit-line-clamp: 3) {
-  .hero-description--clamped {
+  .hero-description__text {
     overflow: hidden;
   }
 }
 
 .hero-read-more {
-  align-self: flex-start;
-  padding: 0;
+  position: absolute;
+  right: 0;
+  bottom: 2px;
+  padding: 0 0 0 8px;
   border: none;
-  background: none;
-  color: var(--primary-color);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, #ffffff 28%);
+  color: #6A5ACD;
   font: inherit;
   font-weight: 700;
   cursor: pointer;

--- a/index.md
+++ b/index.md
@@ -118,10 +118,12 @@ window.onscroll = function() {
     <h1 class="hero-title">This is Tanvir!</h1>
     <button class="role-badge" type="button">Research Fellow</button>
     <div class="hero-description-block">
-      <p class="hero-description hero-description--clamped" id="hero-description">
-        Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of Prof. Sangtae Ahn in his BrainAI Lab. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of Prof. Khan Muhammad. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS).
+      <p class="hero-description" id="hero-description">
+        <span class="hero-description__text hero-description--clamped">
+          Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of Prof. Sangtae Ahn in his BrainAI Lab. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of Prof. Khan Muhammad. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS).
+        </span>
+        <button class="hero-read-more" type="button" aria-haspopup="dialog">…Read more</button>
       </p>
-<button class="hero-read-more" type="button" aria-haspopup="dialog">…Read more</button>
     </div>
     <div class="skill-pills">
       <span class="skill-pill">Computer Vision</span>
@@ -132,18 +134,19 @@ window.onscroll = function() {
   </div>
 </section>
 <script>
-  (function () {
+  document.addEventListener('DOMContentLoaded', function () {
     const description = document.getElementById('hero-description');
-    const readMoreButton = document.querySelector('.hero-read-more');
+    const descriptionText = description?.querySelector('.hero-description__text');
+    const readMoreButton = description?.querySelector('.hero-read-more');
     const modal = document.getElementById('hero-description-modal');
     const modalDialog = modal?.querySelector('.hero-description-modal__dialog');
     const modalClose = modal?.querySelector('.hero-description-modal__close');
     const modalBody = document.getElementById('hero-description-full');
     let lastFocused;
 
-    if (!description || !readMoreButton || !modal || !modalDialog || !modalClose || !modalBody) return;
+    if (!description || !descriptionText || !readMoreButton || !modal || !modalDialog || !modalClose || !modalBody) return;
 
-    const fullText = description.textContent?.trim() || '';
+    const fullText = descriptionText.textContent?.trim() || '';
     modalBody.textContent = fullText;
 
     function handleKeydown(event) {
@@ -182,7 +185,7 @@ window.onscroll = function() {
     modalDialog.addEventListener('click', (event) => {
       event.stopPropagation();
     });
-  })();
+  });
 </script>
 <div class="hero-description-modal" id="hero-description-modal" aria-hidden="true">
   <div class="hero-description-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="hero-description-modal-title">


### PR DESCRIPTION
## Summary
- Clamp the hero bio to the first few lines and position the “Read more” control inline at the end of the visible text with primary color styling
- Keep the modal accessible by loading the full description text dynamically and wiring up interactions after DOMContentLoaded
- Preserve modal close options via button, backdrop click, and Escape while preventing navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd8572ed083308e4903afcc0bd361)