### PR TITLE
Apply navigation and hero mobile adjustments

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -172,9 +172,10 @@ body::after {
   display: none;
   border: none;
   background: transparent;
-  color: #343434;
-  font-size: 17px;
-  font-weight: 700;
+  color: #363636;
+  font-family: "Exo", sans-serif;
+  font-size: 16px;
+  font-weight: 600;
   cursor: pointer;
   padding: 8px 6px;
   margin-left: auto;
@@ -202,9 +203,10 @@ body::after {
 }
 
 .nav-links .page-link {
-  font-size: 17px;
+  font-family: "Exo", sans-serif;
+  font-size: 16px;
   font-weight: 600;
-  color: #343434;
+  color: #363636;
   text-decoration: none;
   border: none;
   background: transparent;
@@ -644,31 +646,40 @@ figure {
   z-index: 1;
 }
 
+
 .hero-description-block {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+  position: relative;
 }
-.hero-description--clamped {
+
+.hero-description {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.hero-description__text {
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
   overflow: hidden;
   max-height: calc(1.7em * 3);
+  padding-right: 68px;
 }
 
 @supports not (-webkit-line-clamp: 3) {
-  .hero-description--clamped {
+  .hero-description__text {
     overflow: hidden;
   }
 }
 
 .hero-read-more {
-  align-self: flex-start;
-  padding: 0;
+  position: absolute;
+  right: 0;
+  bottom: 2px;
+  padding: 0 0 0 8px;
   border: none;
-  background: none;
-  color: var(--primary-color);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0) 0%, #ffffff 28%);
+  color: #6A5ACD;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -861,5 +872,29 @@ body.modal-open {
 
   .content-inner {
     padding: 24px clamp(14px, 6vw, 24px) 52px;
+  }
+
+  .skill-pills {
+    display: none;
+  }
+
+  .hero-greeting {
+    font-size: 16px;
+  }
+
+  .hero-title {
+    font-size: clamp(30px, 4vw, 43px);
+  }
+
+  .role-badge {
+    font-size: 11.2px;
+  }
+
+  .hero-description {
+    font-size: 12.8px;
+  }
+
+  .hero-read-more {
+    font-size: 12.8px;
   }
 }

--- a/index.md
+++ b/index.md
@@ -118,10 +118,12 @@ window.onscroll = function() {
     <h1 class="hero-title">This is Tanvir!</h1>
     <button class="role-badge" type="button">Research Fellow</button>
     <div class="hero-description-block">
-      <p class="hero-description hero-description--clamped" id="hero-description">
-        Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of Prof. Sangtae Ahn in his BrainAI Lab. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of Prof. Khan Muhammad. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS).
+      <p class="hero-description" id="hero-description">
+        <span class="hero-description__text hero-description--clamped">
+          Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of Prof. Sangtae Ahn in his BrainAI Lab. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of Prof. Khan Muhammad. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS).
+        </span>
+        <button class="hero-read-more" type="button" aria-haspopup="dialog">…Read more</button>
       </p>
-<button class="hero-read-more" type="button" aria-haspopup="dialog">…Read more</button>
     </div>
     <div class="skill-pills">
       <span class="skill-pill">Computer Vision</span>
@@ -132,18 +134,19 @@ window.onscroll = function() {
   </div>
 </section>
 <script>
-  (function () {
+  document.addEventListener('DOMContentLoaded', function () {
     const description = document.getElementById('hero-description');
-    const readMoreButton = document.querySelector('.hero-read-more');
+    const descriptionText = description?.querySelector('.hero-description__text');
+    const readMoreButton = description?.querySelector('.hero-read-more');
     const modal = document.getElementById('hero-description-modal');
     const modalDialog = modal?.querySelector('.hero-description-modal__dialog');
     const modalClose = modal?.querySelector('.hero-description-modal__close');
     const modalBody = document.getElementById('hero-description-full');
     let lastFocused;
 
-    if (!description || !readMoreButton || !modal || !modalDialog || !modalClose || !modalBody) return;
+    if (!description || !descriptionText || !readMoreButton || !modal || !modalDialog || !modalClose || !modalBody) return;
 
-    const fullText = description.textContent?.trim() || '';
+    const fullText = descriptionText.textContent?.trim() || '';
     modalBody.textContent = fullText;
 
     function handleKeydown(event) {
@@ -182,7 +185,7 @@ window.onscroll = function() {
     modalDialog.addEventListener('click', (event) => {
       event.stopPropagation();
     });
-  })();
+  });
 </script>
 <div class="hero-description-modal" id="hero-description-modal" aria-hidden="true">
   <div class="hero-description-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="hero-description-modal-title">


### PR DESCRIPTION
## Summary
- set navigation items to use Exo at 16px with #363636 default color across layouts
- hide hero skill keyword pills on small screens while keeping desktop/tablet intact
- scale down hero typography by about 20% on mobile to preserve readability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd8572ed083308e4903afcc0bd361)