### PR TITLE
Update hero bio, modal, mobile nav icon, and link styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
               <img src="{{ '/assets/tanvir_logo.svg' | relative_url }}" alt="Site logo">
             </a>
             <button class="nav-toggle" type="button" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-collections">
-              Menu
+              <span class="nav-toggle__icon" aria-hidden="true"></span>
             </button>
             <div class="nav-collections" id="nav-collections">
               <ul class="nav-links nav-links--left">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -179,6 +179,27 @@ body::after {
   cursor: pointer;
   padding: 8px 6px;
   margin-left: auto;
+  align-items: center;
+  justify-content: center;
+}
+
+.nav-toggle__icon {
+  position: relative;
+  display: inline-block;
+  width: 24px;
+  height: 16px;
+}
+
+.nav-toggle__icon::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+  box-shadow: 0 7px 0 currentColor, 0 14px 0 currentColor;
 }
 
 .nav-links {
@@ -221,13 +242,13 @@ body::after {
 .nav-links .page-link.is-active:focus,
 .nav-links .page-link.is-active:hover {
   color: var(--primary-color);
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .nav-links .page-link:hover,
 .nav-links .page-link:focus {
   color: var(--primary-color);
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 /* Main content container */
@@ -599,43 +620,31 @@ figure {
 }
 
 .hero-description {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
+  display: block;
 }
 
 .hero-description__text {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-  max-height: calc(1.7em * 3);
-  padding-right: 68px;
-}
-
-@supports not (-webkit-line-clamp: 3) {
-  .hero-description__text {
-    overflow: hidden;
-  }
+  display: inline;
 }
 
 .hero-read-more {
-  align-self: flex-end;
-  padding: 2px 0 0;
+  display: inline;
+  padding: 0;
   border: none;
   background: none;
   color: #6A5ACD;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .hero-read-more:hover,
-.hero-read-more:focus {
+.hero-read-more:focus,
+.hero-read-more:active {
   color: #554cbf;
   outline: none;
+  text-decoration: none;
 }
 
 .hero-description-modal {

--- a/index.md
+++ b/index.md
@@ -119,10 +119,10 @@ window.onscroll = function() {
     <button class="role-badge" type="button">Research Fellow</button>
     <div class="hero-description-block">
       <p class="hero-description" id="hero-description">
-        <span class="hero-description__text hero-description--clamped">
-          Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class= "urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class= "urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class= "urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS). Based on his excellent academic and research performance, he was awarded the <i>``Academic Excellence Award Winner''</i> in 2024 by the NIIED, Government of South Korea. Currently, research assistant at VIS2KNOW Lab he is focusing on multiple emerging topics such as image dehazing, image enhancement, invisible watermarking, marked by several research outcomes published in high impactful conferences and journals such as <i><strong>WACV'26, ICCV'25, CIKM'25, WWW'25, ACM MM'24, ACCV'24, Alexandria Engineering Journal and Engineering Application of Artificial Intelligence</strong></i>. Md Tanvir Islam's passion for innovative applications of computer science and artificial intelligence is evident through his <a class= "urls" href="https://tanvirnwu.github.io/pages/publications" target="_blank">research outcomes</a> published at reputable venues.
-</span> 
-<button class="hero-read-more" type="button" aria-haspopup="dialog">…Read more</button>
+        <span class="hero-description__text" id="hero-description-short">
+          Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class="urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class="urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class="urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS).
+        </span>
+        <a class="hero-read-more" id="hero-read-more" href="#" role="button" aria-haspopup="dialog">…Read more</a>
       </p>
     </div>
     <p class="hero-interests">
@@ -134,8 +134,8 @@ window.onscroll = function() {
 <script>
   document.addEventListener('DOMContentLoaded', function () {
     const description = document.getElementById('hero-description');
-    const descriptionText = description?.querySelector('.hero-description__text');
-    const readMoreButton = description?.querySelector('.hero-read-more');
+    const descriptionText = document.getElementById('hero-description-short');
+    const readMoreButton = document.getElementById('hero-read-more');
     const modal = document.getElementById('hero-description-modal');
     const modalDialog = modal?.querySelector('.hero-description-modal__dialog');
     const modalClose = modal?.querySelector('.hero-description-modal__close');
@@ -144,7 +144,7 @@ window.onscroll = function() {
 
     if (!description || !descriptionText || !readMoreButton || !modal || !modalDialog || !modalClose || !modalBody) return;
 
-    const fullHTML = descriptionText.innerHTML?.trim() || '';
+    const fullHTML = `Tanvir is a doctoral research fellow at Kyungpook National University (KNU), South Korea, doing research in Robot Manipulation under the supervision of <a class="urls" href="https://knu-brainai.github.io/professor/" target="_blank">Prof. Sangtae Ahn</a> in his <a class="urls" href="https://knu-brainai.github.io/" target="_blank">BrainAI Lab</a>. Tanvir completed his MS in Computer Science and Engineering at Sungkyunkwan University (SKKU) in South Korea, where he served as a Graduate Research Assistant at the VIS2KNOW Lab under the supervision of <a class="urls" href="https://scholar.google.co.kr/citations?user=k5oUZyQAAAAJ&hl=en" target="_blank">Prof. Khan Muhammad</a>. He has been recognized for his exceptional potential and awarded the prestigious Global Korea Scholarship (GKS). Based on his excellent academic and research performance, he was awarded the \`\`Academic Excellence Award Winner'' in 2024 by the NIIED, Government of South Korea. Currently, research assistant at VIS2KNOW Lab he is focusing on multiple emerging topics such as image dehazing, image enhancement, invisible watermarking, marked by several research outcomes published in high impactful conferences and journals such as <i><strong>WACV'26, ICCV'25, CIKM'25, WWW'25, ACM MM'24, ACCV'24, Alexandria Engineering Journal and Engineering Application of Artificial Intelligence</strong></i>. Md Tanvir Islam's passion for innovative applications of computer science and artificial intelligence is evident through his <a class="urls" href="https://tanvirnwu.github.io/pages/publications" target="_blank">research outcomes</a> published at reputable venues.`;
     modalBody.innerHTML = fullHTML;
 
     function handleKeydown(event) {
@@ -173,7 +173,10 @@ window.onscroll = function() {
       }
     }
 
-    readMoreButton.addEventListener('click', openModal);
+    readMoreButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      openModal();
+    });
     modalClose.addEventListener('click', closeModal);
     modal.addEventListener('click', (event) => {
       if (event.target === modal) {


### PR DESCRIPTION
## Summary
- replace hero description with the full short bio and show it without truncation
- add inline …Read more link styled in the primary color that opens a modal with the complete bio
- ensure the modal content matches the long bio with working links and existing close behaviors
- replace the mobile navigation “Menu” text with an accessible hamburger icon that triggers the same dropdown
- remove underlines from navigation links and the hero “Read more” link across interaction states

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce5b54d848330a0ef95ee89755fce)