### PR TITLE
Remove horizontal divider after hero section

### DIFF
--- a/index.md
+++ b/index.md
@@ -200,7 +200,6 @@ window.onscroll = function() {
   </div>
 </div>
 <section class="news-section">
-  <hr>
   <h3 class="news-heading">📢 News</h3>
   <details class="news-year" open>
     <summary><strong>2025</strong></summary>


### PR DESCRIPTION
### Motivation

- Remove the visual horizontal rule separating the hero area and the news section to match the requested layout change.
- Keep the rest of the page content and behavior unchanged.

### Description

- Deleted the `<hr>` element at the start of the `news-section` in `index.md`.
- Only `index.md` was modified and no CSS or JavaScript files were changed.

### Testing

- Served the site locally with `python -m http.server` and captured a full-page screenshot using Playwright, which completed successfully and produced `artifacts/hero-no-hr.png`.
- No unit or integration test suite was run because this is a static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dd10b0520833085f937df806fac11)